### PR TITLE
Removes submodule test-run

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "test-run"]
-	path = test-run
-	url = https://github.com/tarantool/test-run.git


### PR DESCRIPTION
There are no usage for test-run submodule in module. But it slows down installations by rockspec